### PR TITLE
Allow Repository objects or URIs with user credentials for remote repositories in DefaultTeslaAether

### DIFF
--- a/src/main/java/io/tesla/aether/internal/DefaultTeslaAether.java
+++ b/src/main/java/io/tesla/aether/internal/DefaultTeslaAether.java
@@ -7,6 +7,7 @@
  */
 package io.tesla.aether.internal;
 
+import com.google.common.collect.Lists;
 import io.tesla.aether.Repository;
 import io.tesla.aether.TeslaAether;
 import io.tesla.aether.Workspace;
@@ -94,6 +95,10 @@ public class DefaultTeslaAether implements TeslaAether {
       repositories.add(new Repository(remoteRepositoryUri));
     }
     init(new File(localRepository), repositories);
+  }
+
+  public DefaultTeslaAether(String localRepository, Repository... remoteRepositories) {
+    init(new File(localRepository), Lists.newArrayList(remoteRepositories));
   }
   
   public DefaultTeslaAether(File localRepository, String... remoteRepositoryUris) {


### PR DESCRIPTION
Resolves #3
- Adds the ability to pass in Repository objects to `DefaultTeslaAether` constructor
- Allows passing in user credentials as part of the remote repository URI using the standard `http(s)://user:password@host` scheme
